### PR TITLE
Use linux-x64 as runtime to avoid the "Failed to initialize CoreCLR, HRESULT: 0x80004005" issue

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -42,10 +42,10 @@ PROJECT_FILE=$(x=$(dirname $(find ${BUILD_DIR} -maxdepth 5 -iname Startup.cs | h
 PROJECT_NAME=$(basename ${PROJECT_FILE%.*})
 
 echo "restore ${PROJECT_FILE}"
-dotnet restore $PROJECT_FILE --runtime ubuntu.16.04-x64
+dotnet restore $PROJECT_FILE --runtime linux-x64
 
 echo "publish ${PROJECT_FILE}"
-dotnet publish $PROJECT_FILE --output ${BUILD_DIR}/heroku_output --configuration Release --runtime ubuntu.16.04-x64
+dotnet publish $PROJECT_FILE --output ${BUILD_DIR}/heroku_output --configuration Release --runtime linux-x64
 
 cat << EOT >> ${BUILD_DIR}/Procfile
 web: cd \$HOME/heroku_output && ASPNETCORE_URLS='http://+:\$PORT' dotnet "./${PROJECT_NAME}.dll" --server.urls http://+:\$PORT


### PR DESCRIPTION
Hi @jincod 

I have recently updated my app from v1.0.4 to v2.0, and try to publish it to heroku with your buildpack. But the application is crashed & it's found that an "Failed to initialize CoreCLR, HRESULT: 0x80004005" error has occured. 

After some digging, I found the following: https://github.com/dotnet/cli/issues/1488. Following the guide, I have changed the runtime & publish it to heroku, and it works again! Please see if you could accept this PR for the buildpack, thanks :)  