### PR TITLE
Reference linux-64 instead of ubuntu-64

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -30,7 +30,7 @@ echo "Installing the dependencies"
 apt_install libunwind8 gettext
 
 echo "Installing dotnet"
-install_dotnet $BUILD_DIR 
+install_dotnet $BUILD_DIR
 
 export PATH="/app/dotnet:${PATH}"
 export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}"
@@ -42,10 +42,10 @@ PROJECT_FILE=$(x=$(dirname $(find ${BUILD_DIR} -maxdepth 5 -iname Startup.cs | h
 PROJECT_NAME=$(basename ${PROJECT_FILE%.*})
 
 echo "restore ${PROJECT_FILE}"
-dotnet restore $PROJECT_FILE --runtime ubuntu.16.04-x64
+dotnet restore $PROJECT_FILE --runtime linux-x64
 
 echo "publish ${PROJECT_FILE}"
-dotnet publish $PROJECT_FILE --output ${BUILD_DIR}/heroku_output --configuration Release --runtime ubuntu.16.04-x64
+dotnet publish $PROJECT_FILE --output ${BUILD_DIR}/heroku_output --configuration Release --runtime linux-x64
 
 cat << EOT >> ${BUILD_DIR}/Procfile
 web: cd \$HOME/heroku_output && ASPNETCORE_URLS='http://+:\$PORT' dotnet "./${PROJECT_NAME}.dll" --server.urls http://+:\$PORT


### PR DESCRIPTION
Current master branch of this buildpack results in a fatal error when starting the web app with `Failed to initialize CoreCLR, HRESULT: 0x80004005`

According to https://github.com/dotnet/cli/issues/1488 , the runtime no longer needs to target `ubuntu` directly, but should reference `linux-64`.  This does fix issues with dotnet v2.0.0 final release for me.