### PR TITLE
Reduce publish slug size

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -41,12 +41,12 @@ dotnet --info
 PROJECT_FILE=$(x=$(dirname $(find ${BUILD_DIR} -maxdepth 5 -iname Startup.cs | head -1)); while [[ "$x" =~ $BUILD_DIR ]] ; do find "$x" -maxdepth 1 -name *.csproj; x=`dirname "$x"`; done)
 PROJECT_NAME=$(basename ${PROJECT_FILE%.*})
 
-echo "restore ${PROJECT_FILE}"
-dotnet restore $PROJECT_FILE --runtime linux-x64
-
 echo "publish ${PROJECT_FILE}"
-dotnet publish $PROJECT_FILE --output ${BUILD_DIR}/heroku_output --configuration Release --runtime linux-x64
+dotnet publish $PROJECT_FILE --output ${BUILD_DIR}/heroku_output --configuration Release --runtime linux-x64 --self-contained
+
+echo "cleanup"
+dotnet_cleanup $BUILD_DIR
 
 cat << EOT >> ${BUILD_DIR}/Procfile
-web: cd \$HOME/heroku_output && ASPNETCORE_URLS='http://+:\$PORT' dotnet "./${PROJECT_NAME}.dll" --server.urls http://+:\$PORT
+web: cd \$HOME/heroku_output && chmod +x ${PROJECT_NAME} && ASPNETCORE_URLS='http://+:\$PORT' ./${PROJECT_NAME} --server.urls http://+:\$PORT
 EOT

--- a/lib/utils
+++ b/lib/utils
@@ -9,6 +9,13 @@ function install_dotnet() {
   ln -s ${BUILD_DIR}/.heroku/dotnet /app
 }
 
+function dotnet_cleanup() {
+  local BUILD_DIR="$1"
+
+  rm /app/dotnet
+  rm -rf ${BUILD_DIR}/.heroku/dotnet
+}
+
 # https://github.com/ddollar/heroku-buildpack-apt
 function topic() {
   echo "-----> $*"


### PR DESCRIPTION
@jincod As I am also having an issue of large slug size similar to #19 , I have implemented logic to reduce the slug size when publish to heroku. In my case, the slug size is reduced from 470MB to 81MB.

It is done by publishing a self-contained dotnet app instead of embedding the whole dotnet core runtime into the slug, hence the great reduction in size. See if you could accept this PR, thanks 😄 