### PR TITLE
Set project file and name via environment variables

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -38,8 +38,13 @@ export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}"
 cd $BUILD_DIR
 dotnet --info
 
-PROJECT_FILE="${PROJECT_FILE:-$(x=$(dirname $(find ${BUILD_DIR} -maxdepth 5 -iname Startup.cs | head -1)); while [[ "$x" =~ $BUILD_DIR ]] ; do find "$x" -maxdepth 1 -name *.csproj; x=`dirname "$x"`; done)}"
-PROJECT_NAME="${PROJECT_NAME:-$(basename ${PROJECT_FILE%.*})}"
+if [ -z ${PROJECT_FILE} ]; then
+	PROJECT_FILE=$(x=$(dirname $(find ${BUILD_DIR} -maxdepth 5 -iname Startup.cs | head -1)); while [[ "$x" =~ $BUILD_DIR ]] ; do find "$x" -maxdepth 1 -name *.csproj; x=`dirname "$x"`; done)
+fi
+
+if [ -z ${PROJECT_NAME} ]; then
+	PROJECT_NAME=$(basename ${PROJECT_FILE%.*})
+fi
 
 echo "restore ${PROJECT_FILE}"
 dotnet restore $PROJECT_FILE --runtime linux-x64

--- a/bin/compile
+++ b/bin/compile
@@ -38,8 +38,8 @@ export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}"
 cd $BUILD_DIR
 dotnet --info
 
-PROJECT_FILE=$(x=$(dirname $(find ${BUILD_DIR} -maxdepth 5 -iname Startup.cs | head -1)); while [[ "$x" =~ $BUILD_DIR ]] ; do find "$x" -maxdepth 1 -name *.csproj; x=`dirname "$x"`; done)
-PROJECT_NAME=$(basename ${PROJECT_FILE%.*})
+PROJECT_FILE="${PROJECT_FILE:-$(x=$(dirname $(find ${BUILD_DIR} -maxdepth 5 -iname Startup.cs | head -1)); while [[ "$x" =~ $BUILD_DIR ]] ; do find "$x" -maxdepth 1 -name *.csproj; x=`dirname "$x"`; done)}"
+PROJECT_NAME="${PROJECT_NAME:-$(basename ${PROJECT_FILE%.*})}"
 
 echo "restore ${PROJECT_FILE}"
 dotnet restore $PROJECT_FILE --runtime linux-x64

--- a/lib/utils
+++ b/lib/utils
@@ -4,7 +4,9 @@ function install_dotnet() {
   local BUILD_DIR="$1"
 
   # https://github.com/dotnet/core/blob/master/release-notes/download-archives/2.0.0-download.md
-  curl -sSL -o dotnet.tar.gz https://download.microsoft.com/download/1/B/4/1B4DE605-8378-47A5-B01B-2C79D6C55519/dotnet-sdk-2.0.0-linux-x64.tar.gz
+  # https://download.microsoft.com/download/7/3/A/73A3E4DC-F019-47D1-9951-0453676E059B/dotnet-sdk-2.0.2-linux-x64.tar.gz
+  
+  curl -sSL -o dotnet.tar.gz https://download.microsoft.com/download/7/3/A/73A3E4DC-F019-47D1-9951-0453676E059B/dotnet-sdk-2.0.2-linux-x64.tar.gz
   mkdir -p ${BUILD_DIR}/.heroku/dotnet && tar zxf dotnet.tar.gz -C ${BUILD_DIR}/.heroku/dotnet
   ln -s ${BUILD_DIR}/.heroku/dotnet /app
 }


### PR DESCRIPTION
Added the option to set the `PROJECT_FILE` and `PROJECT_NAME` via environment variables.
I'm working on a project where the project file name differs from the actual assembly name. The published DLL therefore has a different name than the project file and upon running, the assumed DLL name can not be found.