### PR TITLE
remove `dotnet info` invocation

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -39,7 +39,6 @@ export PATH="${BUILD_DIR}/.heroku/dotnet:${PATH}"
 export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}"
 
 cd $BUILD_DIR
-dotnet --info
 
 if [ -z ${PROJECT_FILE:-} ]; then
 	PROJECT_FILE=$(x=$(dirname $(find ${BUILD_DIR} -maxdepth 5 -iname Startup.cs | head -1)); while [[ "$x" =~ $BUILD_DIR ]] ; do find "$x" -maxdepth 1 -name *.csproj; x=`dirname "$x"`; done)


### PR DESCRIPTION
I think this would make sense if the buildpack had a "debug" mode, but currently it just slows things down I think