### PR TITLE
don't override user supplied procfiles

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -57,5 +57,5 @@ dotnet publish $PROJECT_FILE --output ${BUILD_DIR}/heroku_output --configuration
 if [ ! -f ${BUILD_DIR}/Procfile ]; then
 	cat << EOT >> ${BUILD_DIR}/Procfile
 	web: cd \$HOME/heroku_output && ./${PROJECT_NAME}
-	EOT
+EOT
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -54,6 +54,8 @@ fi
 echo "publish ${PROJECT_FILE}"
 dotnet publish $PROJECT_FILE --output ${BUILD_DIR}/heroku_output --configuration Release --runtime linux-x64
 
-cat << EOT >> ${BUILD_DIR}/Procfile
-web: cd \$HOME/heroku_output && ./${PROJECT_NAME}
-EOT
+if [ ! -f ${BUILD_DIR}/Procfile ]; then
+	cat << EOT >> ${BUILD_DIR}/Procfile
+	web: cd \$HOME/heroku_output && ./${PROJECT_NAME}
+	EOT
+fi


### PR DESCRIPTION
This lines up with the behavior of official buildpacks. And is necessary if the user wants additional process types.