### PR TITLE
Self contained dotnet + delete SDK to reduce slug size

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -55,6 +55,9 @@ echo "publish ${PROJECT_FILE}"
 dotnet publish $PROJECT_FILE --output ${BUILD_DIR}/heroku_output --configuration Release --runtime ubuntu-x64 --self-contained=true -p:UseAppHost=true
 chmod +x ${BUILD_DIR}/heroku_output/${PROJECT_NAME}
 
+echo "Cleanup dotnet SDK"
+cleanup_dotnet $BUILD_DIR
+
 if [ ! -f ${BUILD_DIR}/Procfile ]; then
 	cat << EOT >> ${BUILD_DIR}/Procfile
 web: cd \$HOME/heroku_output && ./${PROJECT_NAME}

--- a/lib/utils
+++ b/lib/utils
@@ -14,6 +14,12 @@ function install_dotnet() {
   mkdir -p ${BUILD_DIR}/.heroku/dotnet && tar zxf $CACHE_DIR/$ZIP_NAME -C ${BUILD_DIR}/.heroku/dotnet
 }
 
+function cleanup_dotnet() {
+  local BUILD_DIR="$1"
+  rm -rf /app/dotnet
+  rm -rf ${BUILD_DIR}/.heroku/dotnet
+}
+
 # https://github.com/ddollar/heroku-buildpack-apt
 function topic() {
   echo "-----> $*"


### PR DESCRIPTION
Hi @jincod.

This is essentially a redo of PR #20, but improved a bit and base on the current master branch.

With it, I passed from a 304.9M slug (which causes `Warning: Your slug size exceeds our soft limit (304 MB) which may affect boot time.`) to a 149M slug size!