### PR TITLE
Add 'web' process to Procfile if not already present

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -58,11 +58,16 @@ export NUGET_PACKAGES="${CACHE_DIR}/nuget/cache"
 echo "publish ${PROJECT_FILE}"
 dotnet publish $PROJECT_FILE --output ${BUILD_DIR}/heroku_output --configuration Release --runtime linux-x64
 
-if [ ! -f ${BUILD_DIR}/Procfile ]; then
-	cat << EOT >> ${BUILD_DIR}/Procfile
+UPDATE_PROCFILE=true
+if [ -f ${BUILD_DIR}/Procfile ]; then
+	while IFS='' read -r line || [[ -n "$line" ]]; do
+		if [[ $line == web:* ]]; then
+			UPDATE_PROCFILE=false
+		fi
+	done < ${BUILD_DIR}/Procfile
+fi
+if [ "$UPDATE_PROCFILE" = true ]; then
+        cat << EOT >> ${BUILD_DIR}/Procfile
 web: cd \$HOME/heroku_output && ./${PROJECT_NAME}
 EOT
-else
-	topic "WARNING"
-	echo "Be careful with custom Procfile" | indent
 fi


### PR DESCRIPTION
Up until recently, I was using version 2.1.200 of the buildpack (.NET Core 2.0), but after upgrading my project to .NET Core 2.2, I figured I should also upgrade the buildpack. Suddenly my app didn't have a `web` process anymore, so my site stopped working.

I went troubleshooting and found that between that version and now, a condition had been added to the build process which didn't insert the `web` process if a Procfile already existed. That was a problem, because I wanted to be able to run other processes, but not have to manually add the `web` process, since unlike the build process, I don't have access to the `PROJECT_NAME` variable, so I'd have to make sure to keep my Procfile in sync with my project's name, and it just seemed to unnecessary to me.

So as a compromise, I modified the `compile` script so that it will add `web` not only if the Procfile is missing, but also if there isn't already a `web` process in there. I think this provides a perfect compromise between #27 and #53. I hope this seems an acceptable compromise to you as well, since I'd rather not have to maintain my own separate version of this buildpack just to have this feature. 