### PR TITLE
Add Heroku Testpack API support

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# bin/test <build-dir> <env-dir>
+
+
+### Configure environment
+set -o errexit    # always exit on error
+set -o pipefail   # don't ignore exit codes when piping output
+set -o nounset    # fail on unset variables
+unset GIT_DIR     # Avoid GIT_DIR leak from previous build steps
+
+### Configure directories
+BUILD_DIR=${1:-}
+ENV_DIR=${2:-}
+BP_DIR=$(cd $(dirname ${0:-}); cd ..; pwd)
+
+mkdir -p $BUILD_DIR/.profile.d
+cp $BP_DIR/profile/* $BUILD_DIR/.profile.d/
+
+### Load dependencies
+source $BP_DIR/lib/utils
+
+export_env_dir "$ENV_DIR"
+export NUGET_XMLDOC_MODE=${NUGET_XMLDOC_MODE:-skip}
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=${DOTNET_SKIP_FIRST_TIME_EXPERIENCE:-1}
+export DOTNET_CLI_TELEMETRY_OPTOUT=${DOTNET_CLI_TELEMETRY_OPTOUT:-1}
+
+DOTNET_SDK_VERSION=${DOTNET_SDK_VERSION:-2.2.104}
+DOTNET_RUNTIME_VERSION=${DOTNET_RUNTIME_VERSION:-2.2.2}
+
+export PATH="${BUILD_DIR}/.heroku/dotnet:${PATH}"
+
+cd $BUILD_DIR
+
+if [ -z ${PROJECT_FILE:-} ]; then
+	PROJECT_FILE=$(find ${BUILD_DIR} -maxdepth 5 -name *.csproj -exec grep -l -H 'Microsoft.NET.Test.Sdk' {} \;)
+fi
+
+if [ -z ${PROJECT_NAME:-} ]; then
+	PROJECT_NAME=$(basename ${PROJECT_FILE%.*})
+fi
+
+echo "build ${PROJECT_FILE}"
+dotnet test $PROJECT_FILE -v q --no-build --no-restore --output ${BUILD_DIR}/test_output

--- a/bin/test-compile
+++ b/bin/test-compile
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# bin/test-compile <build-dir> <cache-dir> <env-dir>
+
+### Configure environment
+set -o errexit    # always exit on error
+set -o pipefail   # don't ignore exit codes when piping output
+set -o nounset    # fail on unset variables
+unset GIT_DIR     # Avoid GIT_DIR leak from previous build steps
+
+if [ "$STACK" != "heroku-16" ] && [ "$STACK" != "heroku-18" ]; then
+	echo "Need heroku-16 or heroku-18 stack"
+	exit 1
+fi
+
+### Configure directories
+BUILD_DIR=${1:-}
+CACHE_DIR=${2:-}
+ENV_DIR=${3:-}
+BP_DIR=$(cd $(dirname ${0:-}); cd ..; pwd)
+
+mkdir -p $BUILD_DIR/.profile.d
+cp $BP_DIR/profile/* $BUILD_DIR/.profile.d/
+
+### Load dependencies
+source $BP_DIR/lib/utils
+
+export_env_dir "$ENV_DIR"
+export NUGET_XMLDOC_MODE=${NUGET_XMLDOC_MODE:-skip}
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=${DOTNET_SKIP_FIRST_TIME_EXPERIENCE:-1}
+export DOTNET_CLI_TELEMETRY_OPTOUT=${DOTNET_CLI_TELEMETRY_OPTOUT:-1}
+
+DOTNET_SDK_VERSION=${DOTNET_SDK_VERSION:-2.2.104}
+DOTNET_RUNTIME_VERSION=${DOTNET_RUNTIME_VERSION:-2.2.2}
+
+echo "Installing dotnet"
+install_dotnet $BUILD_DIR $CACHE_DIR $DOTNET_SDK_VERSION $DOTNET_RUNTIME_VERSION
+
+export PATH="${BUILD_DIR}/.heroku/dotnet:${PATH}"
+
+cd $BUILD_DIR
+
+if [ -z ${PROJECT_FILE:-} ]; then
+	PROJECT_FILE=$(find ${BUILD_DIR} -maxdepth 5 -name *.csproj -exec grep -l -H 'Microsoft.NET.Test.Sdk' {} \;)
+fi
+
+if [ -z ${PROJECT_NAME:-} ]; then
+	PROJECT_NAME=$(basename ${PROJECT_FILE%.*})
+fi
+
+if [ -n "$(cat $PROJECT_FILE | grep 'netcoreapp2.0')" ]; then
+	topic "WARNING"
+	echo "For netcoreapp2.0 use https://github.com/jincod/dotnetcore-buildpack#v2.1.200" | indent
+	echo "More info https://github.com/jincod/dotnetcore-buildpack/issues/44" | indent
+fi
+
+export NUGET_PACKAGES="${CACHE_DIR}/nuget/cache"
+
+echo "build ${PROJECT_FILE}"
+dotnet build $PROJECT_FILE --output ${BUILD_DIR}/test_output --configuration Debug


### PR DESCRIPTION
This adds initial [Testpack API](https://devcenter.heroku.com/articles/testpack-api) support.

I have made a [TAP logger](https://github.com/jbowtie/Tap.TestLogger) for Heroku's preferred output format but it's not required for actual compliance so will defer that to a future pull request.