### PR TITLE
Installing dotnet-ef tool

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -56,6 +56,7 @@ export NUGET_PACKAGES="${CACHE_DIR}/nuget/cache"
 echo "publish ${PROJECT_FILE} for ${BUILD_CONFIGURATION}"
 dotnet publish $PROJECT_FILE --output ${BUILD_DIR}/heroku_output --configuration ${BUILD_CONFIGURATION} --runtime linux-x64
 (
+	echo "DOTNET_ROOT at $DOTNET_ROOT"
 	cd ${BUILD_DIR}/heroku_output
 	dotnet ef database update
 )

--- a/bin/compile
+++ b/bin/compile
@@ -35,10 +35,8 @@ BUILD_CONFIGURATION=${BUILD_CONFIGURATION:-Release}
 
 echo "Installing dotnet"
 install_dotnet $BUILD_DIR $CACHE_DIR $DOTNET_SDK_VERSION $DOTNET_RUNTIME_VERSION
-export PATH="$PATH:/app/.dotnet/tools"
 
 export PATH="${BUILD_DIR}/.heroku/dotnet:${PATH}"
-export DOTNET_ROOT="${BUILD_DIR}/.heroku/dotnet"
 
 cd $BUILD_DIR
 
@@ -54,9 +52,6 @@ if [ -n "$(cat $PROJECT_FILE | grep 'netcoreapp2.0')" ]; then
 	echo "More info https://github.com/jincod/dotnetcore-buildpack/issues/44" | indent
 fi
 export NUGET_PACKAGES="${CACHE_DIR}/nuget/cache"
-
-echo "Installing dotnet-ef"
-dotnet tool install --global dotnet-ef
 
 echo "publish ${PROJECT_FILE} for ${BUILD_CONFIGURATION}"
 dotnet publish $PROJECT_FILE --output ${BUILD_DIR}/heroku_output --configuration ${BUILD_CONFIGURATION} --runtime linux-x64

--- a/bin/compile
+++ b/bin/compile
@@ -57,8 +57,8 @@ echo "publish ${PROJECT_FILE} for ${BUILD_CONFIGURATION}"
 dotnet publish $PROJECT_FILE --output ${BUILD_DIR}/heroku_output --configuration ${BUILD_CONFIGURATION} --runtime linux-x64
 (
 	echo "DOTNET_ROOT at $DOTNET_ROOT"
-	cd ${BUILD_DIR}/heroku_output
-	dotnet ef database update
+	#cd ${BUILD_DIR}/heroku_output
+	#dotnet ef database update
 )
 
 if [ -f ${BUILD_DIR}/Procfile ] && grep -q '^web:' ${BUILD_DIR}/Procfile ; then

--- a/bin/compile
+++ b/bin/compile
@@ -35,7 +35,7 @@ BUILD_CONFIGURATION=${BUILD_CONFIGURATION:-Release}
 
 echo "Installing dotnet"
 install_dotnet $BUILD_DIR $CACHE_DIR $DOTNET_SDK_VERSION $DOTNET_RUNTIME_VERSION
-export PATH="$PATH:/app/.dotnet/tools
+export PATH="$PATH:/app/.dotnet/tools"
 
 export PATH="${BUILD_DIR}/.heroku/dotnet:${PATH}"
 

--- a/bin/compile
+++ b/bin/compile
@@ -55,6 +55,10 @@ export NUGET_PACKAGES="${CACHE_DIR}/nuget/cache"
 
 echo "publish ${PROJECT_FILE} for ${BUILD_CONFIGURATION}"
 dotnet publish $PROJECT_FILE --output ${BUILD_DIR}/heroku_output --configuration ${BUILD_CONFIGURATION} --runtime linux-x64
+(
+	cd ${BUILD_DIR}/heroku_output
+	dotnet ef database update
+)
 
 if [ -f ${BUILD_DIR}/Procfile ] && grep -q '^web:' ${BUILD_DIR}/Procfile ; then
 	topic "WARNING"

--- a/bin/compile
+++ b/bin/compile
@@ -53,6 +53,9 @@ if [ -n "$(cat $PROJECT_FILE | grep 'netcoreapp2.0')" ]; then
 fi
 export NUGET_PACKAGES="${CACHE_DIR}/nuget/cache"
 
+echo "Installing dotnet-ef"
+dotnet tool install --global dotnet-ef
+
 echo "publish ${PROJECT_FILE} for ${BUILD_CONFIGURATION}"
 dotnet publish $PROJECT_FILE --output ${BUILD_DIR}/heroku_output --configuration ${BUILD_CONFIGURATION} --runtime linux-x64
 

--- a/bin/compile
+++ b/bin/compile
@@ -55,11 +55,6 @@ export NUGET_PACKAGES="${CACHE_DIR}/nuget/cache"
 
 echo "publish ${PROJECT_FILE} for ${BUILD_CONFIGURATION}"
 dotnet publish $PROJECT_FILE --output ${BUILD_DIR}/heroku_output --configuration ${BUILD_CONFIGURATION} --runtime linux-x64
-(
-	echo "DOTNET_ROOT at $DOTNET_ROOT"
-	#cd ${BUILD_DIR}/heroku_output
-	#dotnet ef database update
-)
 
 if [ -f ${BUILD_DIR}/Procfile ] && grep -q '^web:' ${BUILD_DIR}/Procfile ; then
 	topic "WARNING"

--- a/bin/compile
+++ b/bin/compile
@@ -35,6 +35,7 @@ BUILD_CONFIGURATION=${BUILD_CONFIGURATION:-Release}
 
 echo "Installing dotnet"
 install_dotnet $BUILD_DIR $CACHE_DIR $DOTNET_SDK_VERSION $DOTNET_RUNTIME_VERSION
+export PATH="$PATH:/app/.dotnet/tools
 
 export PATH="${BUILD_DIR}/.heroku/dotnet:${PATH}"
 

--- a/bin/compile
+++ b/bin/compile
@@ -38,6 +38,7 @@ install_dotnet $BUILD_DIR $CACHE_DIR $DOTNET_SDK_VERSION $DOTNET_RUNTIME_VERSION
 export PATH="$PATH:/app/.dotnet/tools"
 
 export PATH="${BUILD_DIR}/.heroku/dotnet:${PATH}"
+export DOTNET_ROOT="${BUILD_DIR}/.heroku/dotnet"
 
 cd $BUILD_DIR
 

--- a/lib/utils
+++ b/lib/utils
@@ -43,6 +43,7 @@ function install_dotnet() {
 
   mkdir -p ${BUILD_DIR}/.heroku/dotnet
   cp -r ${DOTNET_CACHE_LOCATION}/runtime ${BUILD_DIR}/.heroku/dotnet
+  export DOTNET_ROOT="${DOTNET_CACHE_LOCATION}/runtime"
 }
 
 export_env_dir() {

--- a/lib/utils
+++ b/lib/utils
@@ -39,7 +39,7 @@ function install_dotnet() {
   export PATH="${DOTNET_CACHE_LOCATION}/sdk:$PATH"
 
   echo "Installing tool ef into ${DOTNET_CACHE_LOCATION}/sdk"
-  dotnet tool install -g dotnet-ef --tool-path="${DOTNET_CACHE_LOCATION}/sdk"
+  dotnet tool install dotnet-ef --tool-path="${DOTNET_CACHE_LOCATION}/sdk"
 
   mkdir -p ${BUILD_DIR}/.heroku/dotnet
   cp -r ${DOTNET_CACHE_LOCATION}/runtime ${BUILD_DIR}/.heroku/dotnet

--- a/lib/utils
+++ b/lib/utils
@@ -37,6 +37,10 @@ function install_dotnet() {
   fi
 
   export PATH="${DOTNET_CACHE_LOCATION}/sdk:$PATH"
+
+  echo "Installing tool ef into ${DOTNET_CACHE_LOCATION}/sdk"
+  dotnet tool install -g dotnet-ef --tool-path="${DOTNET_CACHE_LOCATION}/sdk"
+
   mkdir -p ${BUILD_DIR}/.heroku/dotnet
   cp -r ${DOTNET_CACHE_LOCATION}/runtime ${BUILD_DIR}/.heroku/dotnet
 }
@@ -48,6 +52,7 @@ export_env_dir() {
     local blacklist_regex=${3:-'^(PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH|LANG)$'}
     if [ -d "$env_dir" ]; then
       for e in $(ls $env_dir); do
+
         echo "$e" | grep -E "$whitelist_regex" | grep -qvE "$blacklist_regex" &&
         export "$e=$(cat $env_dir/$e)"
         :


### PR DESCRIPTION
Added dotnet-ef when installing dotnet (not sure if /sdk is the right directory to install those tools).

Doing so I am now able to run database migrations after publishing, like:

```xml
<Target Name="PrePublishTarget" AfterTargets="Publish">
    <Exec Command="echo  &quot;Migrating Database ...&quot;" />
    <Exec Command="dotnet-ef database update"/>
</Target>
```