### PR TITLE
fix: warning on publish for missing arg

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -67,7 +67,7 @@ fi
 export NUGET_PACKAGES="${CACHE_DIR}/nuget/cache"
 
 info "publish ${PROJECT_FILE} for ${BUILD_CONFIGURATION} on ${OUTPUT_DIR}"
-dotnet publish $PROJECT_FILE --output ${BUILD_DIR}/${OUTPUT_DIR} --configuration ${BUILD_CONFIGURATION} --runtime linux-x64
+dotnet publish $PROJECT_FILE --output ${BUILD_DIR}/${OUTPUT_DIR} --configuration ${BUILD_CONFIGURATION} --runtime linux-x64  --self-contained
 
 if [ -f ${BUILD_DIR}/Procfile ]; then
 	topic "WARNING"


### PR DESCRIPTION
Fixes the following warning during a build on Heroku:

```
/tmp/codon/tmp/cache/dotnet/6.0.100-rc.2.21505.57/sdk/sdk/6.0.100-
rc.2.21505.57/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.targets(1110,5): warning NETSDK1179: One 
of '--self-contained' or '--no-self-contained' options are required when '--runtime' is used.
```

I assume that `--self-contained` is the desired value, [as it is the default for `dotnet`](https://docs.microsoft.com/en-us/dotnet/core/compatibility/sdk/6.0/runtimeidentifier-self-contained).