### PR TITLE
Remove unnecessary runtime copy to reduce slug size

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -37,8 +37,6 @@ BUILD_CONFIGURATION=${BUILD_CONFIGURATION:-Release}
 info "Installing dotnet"
 install_dotnet $BUILD_DIR $CACHE_DIR $DOTNET_SDK_VERSION $DOTNET_RUNTIME_VERSION
 
-export PATH="${BUILD_DIR}/.heroku/dotnet:${PATH}"
-
 cd $BUILD_DIR
 
 if [ -f ${BUILD_DIR}/dotnet-tools.json ] || [ -f ${BUILD_DIR}/.config/dotnet-tools.json ]; then
@@ -67,7 +65,7 @@ fi
 export NUGET_PACKAGES="${CACHE_DIR}/nuget/cache"
 
 info "publish ${PROJECT_FILE} for ${BUILD_CONFIGURATION} on ${OUTPUT_DIR}"
-dotnet publish $PROJECT_FILE --output ${BUILD_DIR}/${OUTPUT_DIR} --configuration ${BUILD_CONFIGURATION} --runtime linux-x64  --self-contained
+dotnet publish $PROJECT_FILE --output ${BUILD_DIR}/${OUTPUT_DIR} --configuration ${BUILD_CONFIGURATION} --runtime linux-x64 --self-contained
 
 if [ -f ${BUILD_DIR}/Procfile ]; then
 	topic "WARNING"

--- a/lib/utils
+++ b/lib/utils
@@ -42,8 +42,6 @@ function install_dotnet() {
   
   topic "Export dotnet to Path"
   export PATH="${DOTNET_CACHE_LOCATION}/sdk:$PATH"
-  mkdir -p ${BUILD_DIR}/.heroku/dotnet
-  cp -r ${DOTNET_CACHE_LOCATION}/runtime ${BUILD_DIR}/.heroku/dotnet
 }
 
 export_env_dir() {

--- a/lib/utils
+++ b/lib/utils
@@ -34,10 +34,6 @@ function install_dotnet() {
     curl -sSL ${DOTNET_SDK_DOWNLOAD_URL} | tar xz -C ${DOTNET_CACHE_LOCATION}/sdk
     find ${DOTNET_CACHE_LOCATION}/sdk/sdk/${DOTNET_SDK_VERSION}/runtimes/* -maxdepth 0 ! -name unix -exec rm -r {} +
     rm -f ${DOTNET_CACHE_LOCATION}/sdk/sdk/${DOTNET_SDK_VERSION}/nuGetPackagesArchive.lzma
-
-    topic "Fetching .NET Runtime"
-    local DOTNET_RUNTIME_DOWNLOAD_URL=https://dotnetcli.blob.core.windows.net/dotnet/Runtime/$DOTNET_RUNTIME_VERSION/dotnet-runtime-$DOTNET_RUNTIME_VERSION-linux-x64.tar.gz
-    curl -sSL ${DOTNET_RUNTIME_DOWNLOAD_URL} | tar xz -C ${DOTNET_CACHE_LOCATION}/runtime
   fi
   
   topic "Export dotnet to Path"


### PR DESCRIPTION
Remove unnecessary runtime copy if we publish with --self-contained option. It reduces the slug size by about 30mb